### PR TITLE
In case there are flavors in the project, the signing does not work

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -172,7 +172,9 @@ task askForPasswords <<
 tasks.whenTaskAdded
 {
 	theTask ->
-		if(theTask.name.equals("packageRelease"))
+		// the name is "packageRelease" with no flavor
+		// in case of flavors, the names could vary, e.g. "packageDemoRelease", ...
+		if(theTask.name.startsWith("package") && theTask.name.endsWith("Release"))
 		{
 			theTask.dependsOn "askForPasswords"
 		}


### PR DESCRIPTION
Hi!
In case someone gets inspired the way you obtain signing credentials from the properties file or from the user input -> it does not work if you use flavors.
I took me a while to realise what was wrong, so I created PR just to save some time for others.

The trick is not to compare task name to "packageRelease" but to "package*Release" where the asterisk stands for the flavor name.

M